### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,10 @@ Use `ps_security_gate` instead of `ps_security_scan` to enforce the policy — i
 ```
 
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/chrbailey-promptspeak-mcp-server).
+
 ## How it works: 9-stage validation pipeline
 
 Every tool call passes through this pipeline. If any stage fails, execution is blocked.


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/chrbailey-promptspeak-mcp-server).