### PR TITLE
Close drift/execution/handshake gaps with real, pluggable implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Pluggable tool executor** (`ToolExecutor`). The gatekeeper's STEP 6 now runs a registered executor instead of the built-in simulation when one is provided via `new Gatekeeper(eviction, { executor })` or `gatekeeper.setExecutor(...)`. Defaults to simulation (safe, unchanged behavior). Executor exceptions are recorded as failed executions rather than crashing the pipeline.
+- **Pluggable, content-aware embeddings** (`EmbeddingProvider` seam in `src/utils/embedding-provider.ts`). Drift embeddings now incorporate behavioral content (tool arguments + results), so drift reflects what an agent actually did — not just the frame's symbol glyphs. The default provider is deterministic and local (no network, no model dependency), preserving validation latency; a real semantic model can be injected via `setEmbeddingProvider()`. Frame-only operations remain byte-identical to prior behavior (backward compatible).
+- **Authenticated handshake** (HMAC-SHA256 challenge–response): `issueChallenge()` / `proveChallenge()` / `verifyChallenge()` with single-use, expiring nonces and constant-time comparison. Secret sourced from `PROMPTSPEAK_HANDSHAKE_SECRET` (falls back to an ephemeral per-process key). Existing version-check/echo behavior is unchanged.
+
+### Changed
+
+- `DriftDetectionEngine.recordOperation()` and `ContinuousMonitor.recordOperation()` accept an optional `OperationContext` (args/result) carrying behavioral signal. `ps_execute` and the gatekeeper thread this through automatically.
+
+### Security
+
+- Tripwire injection and selection now use crypto-backed randomness (`crypto.randomInt`) instead of `Math.random`, removing predictability for an adversary who knows the injection rate.
+
 ## [0.4.0] - 2026-03-14
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,10 @@
 
 Pre-execution governance layer for AI agents. Intercepts MCP tool calls, validates against deterministic rules, blocks or holds risky operations for human approval. Validation latency: 0.164ms avg (P95: 0.368ms).
 
-**v0.4.1** — 834 tests, 56 MCP tools, MIT licensed, published as `@chrbailey/promptspeak-mcp-server`.
+**v0.4.1** — 879 tests, 56 MCP tools, MIT licensed, published as `@chrbailey/promptspeak-mcp-server`.
+
+> **Execution model:** STEP 6 of the pipeline runs a pluggable `ToolExecutor` when registered (`gatekeeper.setExecutor`), otherwise it simulates (safe default — unchanged behavior). Drift embeddings are content-aware via the `EmbeddingProvider` seam (deterministic-local by default; inject a real model with `setEmbeddingProvider`). The handshake supports HMAC-SHA256 challenge–response (`PROMPTSPEAK_HANDSHAKE_SECRET`).
+
 HTTPS live at `https://promptspeak.admin-as-a-service.com/mcp` (Cloudflare Tunnel → Mac Mini).
 Safety annotations on all 56 tools. Streamable HTTP transport. Connectors submission: all requirements met, form submitted 2026-03-21.
 

--- a/src/drift/index.ts
+++ b/src/drift/index.ts
@@ -17,6 +17,15 @@ import { BaselineStore } from './baseline.js';
 import { TripwireInjector } from './tripwire.js';
 import { CircuitBreaker } from './circuit-breaker.js';
 import { ContinuousMonitor } from './monitor.js';
+import type { OperationContext } from '../utils/embedding-provider.js';
+
+export type { OperationContext } from '../utils/embedding-provider.js';
+export {
+  getEmbeddingProvider,
+  setEmbeddingProvider,
+  resetEmbeddingProvider,
+  type EmbeddingProvider,
+} from '../utils/embedding-provider.js';
 
 // Create integrated drift detection engine
 export class DriftDetectionEngine {
@@ -100,10 +109,11 @@ export class DriftDetectionEngine {
     agentId: string,
     frame: string,
     action: string,
-    success: boolean
+    success: boolean,
+    context?: OperationContext
   ): { type: string; message: string } | null {
-    // Record with monitor
-    this.monitor.recordOperation(agentId, frame, action, success);
+    // Record with monitor (context carries behavioral signal for drift)
+    this.monitor.recordOperation(agentId, frame, action, success, undefined, context);
 
     // Check drift status
     const status = this.monitor.getDriftStatus(agentId);

--- a/src/drift/monitor.ts
+++ b/src/drift/monitor.ts
@@ -13,7 +13,8 @@ import { BaselineStore } from './baseline.js';
 import { TripwireInjector } from './tripwire.js';
 import { CircuitBreaker } from './circuit-breaker.js';
 import { generateAlertId } from '../utils/hash.js';
-import { calculateDriftScore, generateFrameEmbedding } from '../utils/embeddings.js';
+import { calculateDriftScore } from '../utils/embeddings.js';
+import { getEmbeddingProvider, type OperationContext } from '../utils/embedding-provider.js';
 import { FrameValidator } from '../gatekeeper/validator.js';
 import { DynamicResolver } from '../gatekeeper/resolver.js';
 
@@ -90,7 +91,8 @@ export class ContinuousMonitor {
     frame: string | ParsedFrame,
     action: string | string[],
     success: boolean,
-    senderId?: string
+    senderId?: string,
+    context?: OperationContext
   ): DriftMetrics {
     // Handle string frame
     const parsedFrame: ParsedFrame = typeof frame === 'string'
@@ -115,7 +117,7 @@ export class ContinuousMonitor {
     // Handle string action
     const behavior = typeof action === 'string' ? [action] : action;
 
-    return this._recordOperation(agentId, parsedFrame, behavior, success, senderId);
+    return this._recordOperation(agentId, parsedFrame, behavior, success, senderId, context);
   }
 
   /**
@@ -127,7 +129,8 @@ export class ContinuousMonitor {
     frame: ParsedFrame,
     behavior: string[],
     success: boolean,
-    senderId?: string
+    senderId?: string,
+    context?: OperationContext
   ): DriftMetrics {
     if (!this.enabled) {
       return this.getMetrics(agentId);
@@ -136,8 +139,9 @@ export class ContinuousMonitor {
     const metrics = this.getMetrics(agentId);
     const now = Date.now();
 
-    // 1. Record embedding
-    const embedding = generateFrameEmbedding(frame);
+    // 1. Record embedding — includes behavioral content (args/results) when
+    //    available, so drift reflects what the agent did, not just the frame glyphs.
+    const embedding = getEmbeddingProvider().embed({ frame, behavior, context });
     this.recordEmbedding(agentId, embedding);
 
     // 2. Compare to baseline if available

--- a/src/drift/tripwire.ts
+++ b/src/drift/tripwire.ts
@@ -5,8 +5,12 @@
 // The agent doesn't know which operations are tripwires.
 // ═══════════════════════════════════════════════════════════════════════════
 
+import { randomInt } from 'crypto';
 import type { TripwireResult, ParsedFrame } from '../types/index.js';
 import { generateTripwireId } from '../utils/hash.js';
+
+// Resolution for crypto-backed probability draws.
+const RNG_RESOLUTION = 1_000_000;
 
 // Predefined tripwire test cases
 interface TripwireTestCase {
@@ -94,16 +98,20 @@ export class TripwireInjector {
    */
   shouldInject(): boolean {
     if (!this.enabled) return false;
-    return Math.random() < this.injectionRate;
+    if (this.injectionRate <= 0) return false;
+    if (this.injectionRate >= 1) return true;
+    // Crypto-backed draw: an adversary who knows the rate cannot predict
+    // which operations are tripwires (Math.random is predictable).
+    return randomInt(0, RNG_RESOLUTION) < this.injectionRate * RNG_RESOLUTION;
   }
 
   /**
    * Get a random tripwire test case.
    */
   getRandomTripwire(): TripwireTestCase {
-    // 50% chance of valid, 50% chance of invalid
-    const pool = Math.random() < 0.5 ? VALID_TRIPWIRES : INVALID_TRIPWIRES;
-    return pool[Math.floor(Math.random() * pool.length)];
+    // 50% chance of valid, 50% chance of invalid (crypto-backed)
+    const pool = randomInt(0, 2) === 0 ? VALID_TRIPWIRES : INVALID_TRIPWIRES;
+    return pool[randomInt(0, pool.length)];
   }
 
   /**
@@ -111,7 +119,7 @@ export class TripwireInjector {
    */
   getTripwire(type: 'valid' | 'invalid'): TripwireTestCase {
     const pool = type === 'valid' ? VALID_TRIPWIRES : INVALID_TRIPWIRES;
-    return pool[Math.floor(Math.random() * pool.length)];
+    return pool[randomInt(0, pool.length)];
   }
 
   /**

--- a/src/gatekeeper/index.ts
+++ b/src/gatekeeper/index.ts
@@ -64,12 +64,31 @@ const DEFAULT_EVICTION_CONFIG: AgentEvictionConfig = {
   logEvictions: true,
 };
 
+/**
+ * A real tool executor. When set, the gatekeeper runs this AFTER all
+ * pre-execution checks pass, instead of the built-in simulation. Synchronous
+ * by design — the gatekeeper's execute() is synchronous and the codebase uses
+ * synchronous I/O (better-sqlite3). Executors that must perform async work
+ * should dispatch it and return a handle/acknowledgement synchronously.
+ *
+ * Throwing from an executor is treated as a failed execution (not a crash):
+ * the failure is recorded for drift and surfaced in the ExecuteResult.
+ */
+export type ToolExecutor = (
+  tool: string,
+  args: Record<string, unknown>,
+  ctx: { agentId: string; frame: string }
+) => unknown;
+
 export class Gatekeeper {
   private resolver: DynamicResolver;
   private validator: FrameValidator;
   private interceptor: ActionInterceptor;
   private coverageCalculator: CoverageCalculator;
   private holdManager: HoldManager;
+
+  // Optional real executor. Defaults to simulation when unset (safe default).
+  private executor?: ToolExecutor;
 
   // Frame cache for chain validation (with eviction)
   private activeFrames: Map<string, ResolvedFrame> = new Map();
@@ -99,12 +118,16 @@ export class Gatekeeper {
     evictedByInactivity: 0,
   };
 
-  constructor(evictionConfig?: Partial<AgentEvictionConfig>) {
+  constructor(
+    evictionConfig?: Partial<AgentEvictionConfig>,
+    options?: { executor?: ToolExecutor }
+  ) {
     this.resolver = new DynamicResolver();
     this.validator = new FrameValidator();
     this.interceptor = new ActionInterceptor();
     this.coverageCalculator = new CoverageCalculator();
     this.holdManager = holdManager;  // Use singleton
+    this.executor = options?.executor;
     this.evictionConfig = { ...DEFAULT_EVICTION_CONFIG, ...evictionConfig };
 
     // Start periodic cleanup if enabled
@@ -138,6 +161,19 @@ export class Gatekeeper {
    */
   getEvictionConfig(): AgentEvictionConfig {
     return { ...this.evictionConfig };
+  }
+
+  /**
+   * Register (or clear) a real tool executor. When set, it replaces the
+   * built-in simulation in STEP 6 of the execution pipeline.
+   */
+  setExecutor(executor: ToolExecutor | undefined): void {
+    this.executor = executor;
+  }
+
+  /** Whether a real executor is currently registered. */
+  hasExecutor(): boolean {
+    return this.executor !== undefined;
   }
 
   /**
@@ -693,13 +729,51 @@ export class Gatekeeper {
 
     // ═══════════════════════════════════════════════════════════════════════
     // STEP 6: TOOL EXECUTION
-    // All pre-execution checks passed - now execute
+    // All pre-execution checks passed - now execute via the registered executor,
+    // falling back to simulation when none is configured (safe default).
     // ═══════════════════════════════════════════════════════════════════════
     preFlightCheck.passed = true;
-    const result = this.simulateToolExecution(tool, effectiveArgs);
+    let result: unknown;
+    let executionSucceeded = true;
+    let executionError: string | undefined;
+    try {
+      result = this.executor
+        ? this.executor(tool, effectiveArgs, { agentId, frame: effectiveFrame })
+        : this.simulateToolExecution(tool, effectiveArgs);
+    } catch (err) {
+      executionSucceeded = false;
+      executionError = err instanceof Error ? err.message : String(err);
+      result = { tool, executed: false, error: executionError };
+    }
 
-    // Record successful operation in drift engine
-    driftEngine.recordOperation(agentId, frame, tool, true);
+    // Record operation in drift engine with behavioral context (args + result),
+    // so drift detection reacts to actual behavior, not just frame composition.
+    driftEngine.recordOperation(agentId, frame, tool, executionSucceeded, {
+      args: effectiveArgs,
+      result,
+    });
+
+    // A real executor that threw is a failed execution, not a pipeline crash.
+    if (!executionSucceeded) {
+      this.recordExecution(agentId, request, decision, result);
+      this.activeFrames.set(agentId, resolved);
+      return {
+        success: false,
+        allowed: true,
+        error: executionError,
+        result,
+        preFlightCheck,
+        interceptorDecision: {
+          ...decision,
+          preFlightChecks: {
+            circuitBreakerPassed: true,
+            driftPredictionPassed: preFlightCheck.checks.driftPrediction.passed,
+            baselineCheckPassed: preFlightCheck.checks.baseline.passed,
+            predictedDriftScore,
+          },
+        },
+      };
+    }
 
     // ═══════════════════════════════════════════════════════════════════════
     // STEP 7: POST-AUDIT

--- a/src/handshake/protocol.ts
+++ b/src/handshake/protocol.ts
@@ -8,6 +8,7 @@
  * Enables agents to verify PromptSpeak capability before issuing commands.
  */
 
+import { createHmac, randomBytes, timingSafeEqual } from 'crypto';
 import { parse, ParseError } from '../grammar/parser.js';
 import { expand } from '../grammar/expander.js';
 
@@ -26,11 +27,124 @@ export interface HandshakeResponse {
   error?: string;
 }
 
+export interface HandshakeChallenge {
+  nonce: string;
+  expiresAt: number;
+  ttlMs: number;
+}
+
+export interface ChallengeVerification {
+  verified: boolean;
+  reason?: string;
+}
+
+export interface HandshakeOptions {
+  /** Shared secret for HMAC auth. Falls back to env, then an ephemeral per-process key. */
+  secret?: string;
+  /** Challenge time-to-live in milliseconds (default 60s). */
+  challengeTtlMs?: number;
+}
+
+const DEFAULT_CHALLENGE_TTL_MS = 60_000;
+
 export class HandshakeProtocol {
   private capabilities: HandshakeCapabilities;
+  private readonly secret: string;
+  private readonly secretIsEphemeral: boolean;
+  private readonly challengeTtlMs: number;
+  // nonce -> expiry timestamp (single-use, expiring)
+  private readonly pendingChallenges = new Map<string, number>();
 
-  constructor(capabilities: HandshakeCapabilities) {
+  constructor(capabilities: HandshakeCapabilities, options?: HandshakeOptions) {
     this.capabilities = capabilities;
+    this.challengeTtlMs = options?.challengeTtlMs ?? DEFAULT_CHALLENGE_TTL_MS;
+
+    const configured = options?.secret ?? process.env.PROMPTSPEAK_HANDSHAKE_SECRET;
+    if (configured && configured.length > 0) {
+      this.secret = configured;
+      this.secretIsEphemeral = false;
+    } else {
+      // No shared secret configured: generate an ephemeral per-process key so
+      // prove/verify still round-trips within this instance. Cross-process
+      // verification requires a configured PROMPTSPEAK_HANDSHAKE_SECRET.
+      this.secret = randomBytes(32).toString('hex');
+      this.secretIsEphemeral = true;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // AUTHENTICATED CHALLENGE–RESPONSE (HMAC-SHA256)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** True when a durable (non-ephemeral) shared secret is in use. */
+  hasSharedSecret(): boolean {
+    return !this.secretIsEphemeral;
+  }
+
+  /**
+   * Verifier side: issue a single-use, expiring challenge nonce.
+   * The peer must return HMAC-SHA256(secret, nonce) via proveChallenge().
+   */
+  issueChallenge(): HandshakeChallenge {
+    this.pruneExpiredChallenges();
+    const nonce = randomBytes(16).toString('hex');
+    const expiresAt = Date.now() + this.challengeTtlMs;
+    this.pendingChallenges.set(nonce, expiresAt);
+    return { nonce, expiresAt, ttlMs: this.challengeTtlMs };
+  }
+
+  /**
+   * Prover side: compute the HMAC proof for a challenge nonce using the secret.
+   */
+  proveChallenge(nonce: string): string {
+    return this.computeMac(nonce);
+  }
+
+  /**
+   * Verifier side: verify a peer's HMAC proof against an issued nonce.
+   * Constant-time comparison; nonce is consumed (single-use) on any attempt.
+   */
+  verifyChallenge(nonce: string, mac: string): ChallengeVerification {
+    // Read before pruning so a genuinely-expired (but still tracked) nonce is
+    // reported as "expired" rather than "unknown".
+    const expiresAt = this.pendingChallenges.get(nonce);
+    if (expiresAt === undefined) {
+      return { verified: false, reason: 'Unknown or already-used challenge nonce' };
+    }
+    // Consume the nonce regardless of outcome to prevent replay/brute-force.
+    this.pendingChallenges.delete(nonce);
+
+    if (Date.now() > expiresAt) {
+      return { verified: false, reason: 'Challenge expired' };
+    }
+
+    const expected = Buffer.from(this.computeMac(nonce), 'hex');
+    let provided: Buffer;
+    try {
+      provided = Buffer.from(mac, 'hex');
+    } catch {
+      return { verified: false, reason: 'Malformed MAC' };
+    }
+
+    if (provided.length !== expected.length) {
+      return { verified: false, reason: 'MAC length mismatch' };
+    }
+
+    const ok = timingSafeEqual(provided, expected);
+    return ok ? { verified: true } : { verified: false, reason: 'MAC mismatch' };
+  }
+
+  private computeMac(nonce: string): string {
+    return createHmac('sha256', this.secret).update(nonce).digest('hex');
+  }
+
+  private pruneExpiredChallenges(): void {
+    const now = Date.now();
+    for (const [nonce, expiresAt] of this.pendingChallenges) {
+      if (now > expiresAt) {
+        this.pendingChallenges.delete(nonce);
+      }
+    }
   }
 
   /**

--- a/src/tools/ps_execute.ts
+++ b/src/tools/ps_execute.ts
@@ -112,12 +112,13 @@ export async function ps_execute(request: PSExecuteRequest): Promise<PSExecuteRe
     // Step 3: Execute through gatekeeper
     const executeResult = await gatekeeper.execute(executeRequest);
 
-    // Step 4: Record drift metrics
+    // Step 4: Record drift metrics with behavioral context (args + result)
     const driftAlert = driftEngine.recordOperation(
       request.agentId,
       request.frame,
       actionTool,
-      executeResult.success
+      executeResult.success,
+      { args: normalizedAction.arguments, result: executeResult.result }
     );
 
     // Step 5: Get updated drift status
@@ -158,7 +159,8 @@ export async function ps_execute(request: PSExecuteRequest): Promise<PSExecuteRe
       request.agentId,
       request.frame,
       actionTool,
-      false
+      false,
+      { args: normalizedAction.arguments }
     );
 
     return {

--- a/src/utils/embedding-provider.ts
+++ b/src/utils/embedding-provider.ts
@@ -1,0 +1,116 @@
+// ═══════════════════════════════════════════════════════════════════════════
+// PROMPTSPEAK MCP SERVER - EMBEDDING PROVIDER SEAM
+// ═══════════════════════════════════════════════════════════════════════════
+// Drift detection compares embeddings over time. Historically the only signal
+// was the frame's symbol glyphs (generateFrameEmbedding), which carries NO
+// information about what an agent actually did — so two operations with the same
+// frame but wildly different arguments/results were indistinguishable.
+//
+// This module introduces a pluggable provider so behavioral content (arguments,
+// results) contributes to the embedding. The default provider is deterministic
+// and local (no network, no model), preserving latency. A real embedding model
+// can be injected via setEmbeddingProvider() for semantic drift detection.
+//
+// Backward compatibility: when no behavioral context is supplied, the default
+// provider returns exactly generateFrameEmbedding(frame), so existing callers
+// (and tests) that record frame-only operations are unaffected.
+// ═══════════════════════════════════════════════════════════════════════════
+
+import type { ParsedFrame } from '../types/index.js';
+import {
+  generateFrameEmbedding,
+  generateContentEmbedding,
+  blendEmbeddings,
+} from './embeddings.js';
+
+/** Behavioral context for an operation — the actual inputs/outputs of a tool call. */
+export interface OperationContext {
+  args?: Record<string, unknown>;
+  result?: unknown;
+}
+
+export interface EmbeddingInput {
+  frame: ParsedFrame;
+  /** Behavior labels (e.g. tool names). Reserved for richer providers. */
+  behavior?: string[];
+  /** Behavioral content — drives content-sensitive drift. */
+  context?: OperationContext;
+}
+
+export interface EmbeddingProvider {
+  readonly name: string;
+  embed(input: EmbeddingInput): number[];
+}
+
+/**
+ * Serialize behavioral context into a stable string for embedding.
+ * Object keys are sorted so semantically identical payloads hash identically.
+ * Returns '' when there is no behavioral content (preserves legacy frame-only path).
+ */
+export function serializeContext(context?: OperationContext): string {
+  if (!context) return '';
+  const parts: string[] = [];
+  if (context.args && Object.keys(context.args).length > 0) {
+    parts.push(stableStringify(context.args));
+  }
+  if (context.result !== undefined) {
+    parts.push(stableStringify(context.result));
+  }
+  return parts.join('::');
+}
+
+function stableStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value, (_key, val) => {
+      if (val && typeof val === 'object' && !Array.isArray(val)) {
+        return Object.keys(val as Record<string, unknown>)
+          .sort()
+          .reduce<Record<string, unknown>>((acc, k) => {
+            acc[k] = (val as Record<string, unknown>)[k];
+            return acc;
+          }, {});
+      }
+      return val;
+    });
+  } catch {
+    return String(value);
+  }
+}
+
+/** Relative weight of the frame structure vs behavioral content when blending. */
+const FRAME_WEIGHT = 0.5;
+
+/**
+ * Default deterministic, local provider. No external dependencies.
+ * Combines frame-structure signal with behavioral-content signal.
+ */
+export class DeterministicEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'deterministic-local';
+
+  embed(input: EmbeddingInput): number[] {
+    const frameVec = generateFrameEmbedding(input.frame);
+    const content = serializeContext(input.context);
+    if (!content) {
+      // No behavioral signal — identical to legacy behavior.
+      return frameVec;
+    }
+    const contentVec = generateContentEmbedding(content);
+    return blendEmbeddings(frameVec, contentVec, FRAME_WEIGHT);
+  }
+}
+
+let activeProvider: EmbeddingProvider = new DeterministicEmbeddingProvider();
+
+export function getEmbeddingProvider(): EmbeddingProvider {
+  return activeProvider;
+}
+
+/** Inject a custom provider (e.g. a real semantic embedding model). */
+export function setEmbeddingProvider(provider: EmbeddingProvider): void {
+  activeProvider = provider;
+}
+
+/** Restore the default deterministic provider (useful for tests). */
+export function resetEmbeddingProvider(): void {
+  activeProvider = new DeterministicEmbeddingProvider();
+}

--- a/src/utils/embeddings.ts
+++ b/src/utils/embeddings.ts
@@ -129,3 +129,59 @@ export function calculateDriftScore(baseline: number[], current: number[]): numb
   // Normalize to 0-1 range (assuming max distance is sqrt(2) for normalized vectors)
   return Math.min(1, distance / Math.sqrt(2));
 }
+
+/**
+ * Generate a deterministic embedding from arbitrary behavioral content
+ * (serialized tool arguments, results, etc).
+ *
+ * Unlike generateFrameEmbedding — which only captures the symbol glyphs of a
+ * frame — this captures the actual content of an operation, so drift detection
+ * can react to behavioral change, not just frame composition. It is deterministic
+ * and local (no network, no model dependency), which keeps validation latency flat.
+ * For semantic drift, inject a real model via the EmbeddingProvider seam.
+ */
+export function generateContentEmbedding(content: string): number[] {
+  const embedding: number[] = new Array(EMBEDDING_DIM).fill(0);
+  if (!content) return embedding;
+
+  // Distribute each character's influence across the vector deterministically.
+  // Two independent projections reduce collisions between similar strings.
+  for (let i = 0; i < content.length; i++) {
+    const code = content.charCodeAt(i);
+    const d1 = (code + i) % EMBEDDING_DIM;
+    embedding[d1] += Math.sin(code * 0.131 + i * 0.077);
+    const d2 = (code * 7 + i * 13) % EMBEDDING_DIM;
+    embedding[d2] += Math.cos(code * 0.217 + i * 0.043);
+  }
+
+  // Normalize to unit length so distances stay in the same scale as frame vectors.
+  const magnitude = Math.sqrt(embedding.reduce((sum, v) => sum + v * v, 0));
+  if (magnitude > 0) {
+    for (let i = 0; i < EMBEDDING_DIM; i++) {
+      embedding[i] /= magnitude;
+    }
+  }
+
+  return embedding;
+}
+
+/**
+ * Blend two embeddings by a weight on the first, returning a re-normalized vector.
+ * weightA = 1 yields purely `a`; weightA = 0 yields purely `b`.
+ */
+export function blendEmbeddings(a: number[], b: number[], weightA = 0.5): number[] {
+  if (a.length !== b.length) {
+    throw new Error('Embedding dimensions must match');
+  }
+  const out: number[] = new Array(a.length).fill(0);
+  for (let i = 0; i < a.length; i++) {
+    out[i] = weightA * a[i] + (1 - weightA) * b[i];
+  }
+  const magnitude = Math.sqrt(out.reduce((sum, v) => sum + v * v, 0));
+  if (magnitude > 0) {
+    for (let i = 0; i < out.length; i++) {
+      out[i] /= magnitude;
+    }
+  }
+  return out;
+}

--- a/tests/unit/gap-fixes.test.ts
+++ b/tests/unit/gap-fixes.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Gatekeeper, type ToolExecutor } from '../../src/gatekeeper/index.js';
+import { driftEngine } from '../../src/drift/index.js';
+import {
+  DeterministicEmbeddingProvider,
+  serializeContext,
+} from '../../src/utils/embedding-provider.js';
+import {
+  generateContentEmbedding,
+  blendEmbeddings,
+  euclideanDistance,
+} from '../../src/utils/embeddings.js';
+import { TripwireInjector } from '../../src/drift/tripwire.js';
+import type { ParsedFrame } from '../../src/types/index.js';
+
+function frame(raw: string): ParsedFrame {
+  return {
+    raw,
+    symbols: [...raw].map((s) => ({
+      symbol: s,
+      category: 'unknown' as const,
+      definition: { name: s, canonical: s, color: '#888888', category: 'unknown' },
+    })),
+    mode: raw[0],
+    modifiers: [],
+    domain: null,
+    source: null,
+    constraints: [],
+    action: null,
+    entity: null,
+    metadata: {},
+  } as ParsedFrame;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// GAP 1: Pluggable tool executor (was: simulateToolExecution stub)
+// ───────────────────────────────────────────────────────────────────────────
+describe('Gatekeeper executor seam', () => {
+  // Frame: strict(⊕) financial(◊) execute(▶) secondary(β). Use a financial+execute
+  // tool so coverage passes; make thresholds/holds permissive so the pipeline
+  // reaches STEP 6 (we are testing execution, not the gating checks here).
+  const validFrame = '⊕◊▶β';
+  const financialTool = 'process_payment';
+
+  function permissiveGatekeeper(executor?: ToolExecutor): Gatekeeper {
+    driftEngine.reset();
+    const gk = new Gatekeeper(
+      { enablePeriodicCleanup: false },
+      executor ? { executor } : undefined
+    );
+    gk.setThresholds({ preExecute: 0, postAudit: 0, coverageMinimum: 0, driftThreshold: 1 });
+    gk.setExecutionControlConfig({
+      enableCircuitBreakerCheck: true,
+      enablePreFlightDriftPrediction: false,
+      enableBaselineComparison: false,
+      holdOnDriftPrediction: false,
+      holdOnLowConfidence: false,
+      enableMcpValidation: false,
+    });
+    return gk;
+  }
+
+  it('defaults to simulation when no executor is registered', () => {
+    const gk = permissiveGatekeeper();
+    expect(gk.hasExecutor()).toBe(false);
+    const res = gk.execute({ agentId: 'a1', frame: validFrame, tool: financialTool, arguments: {} });
+    expect(res.allowed).toBe(true);
+    expect(res.success).toBe(true);
+    // Simulated result shape
+    expect(res.result).toMatchObject({ tool: financialTool, executed: true });
+  });
+
+  it('invokes a registered executor and returns its result', () => {
+    const calls: Array<{ tool: string; args: Record<string, unknown> }> = [];
+    const executor: ToolExecutor = (tool, args) => {
+      calls.push({ tool, args });
+      return { ok: true, echoed: args };
+    };
+    const gk = permissiveGatekeeper(executor);
+    expect(gk.hasExecutor()).toBe(true);
+
+    const res = gk.execute({
+      agentId: 'a2',
+      frame: validFrame,
+      tool: financialTool,
+      arguments: { x: 1 },
+    });
+
+    expect(res.success).toBe(true);
+    expect(res.result).toEqual({ ok: true, echoed: { x: 1 } });
+    expect(calls).toEqual([{ tool: financialTool, args: { x: 1 } }]);
+  });
+
+  it('treats an executor throw as a failed execution, not a crash', () => {
+    const executor: ToolExecutor = () => {
+      throw new Error('boom');
+    };
+    const gk = permissiveGatekeeper(executor);
+
+    const res = gk.execute({ agentId: 'a3', frame: validFrame, tool: financialTool, arguments: {} });
+
+    expect(res.success).toBe(false);
+    expect(res.allowed).toBe(true);
+    expect(res.error).toBe('boom');
+    expect(res.result).toMatchObject({ executed: false, error: 'boom' });
+  });
+
+  it('can register/clear an executor after construction', () => {
+    const gk = permissiveGatekeeper();
+    gk.setExecutor(() => ({ ran: true }));
+    expect(gk.hasExecutor()).toBe(true);
+    expect(
+      gk.execute({ agentId: 'a4', frame: validFrame, tool: financialTool, arguments: {} }).result
+    ).toEqual({ ran: true });
+    gk.setExecutor(undefined);
+    expect(gk.hasExecutor()).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// GAP 2: Content-aware, pluggable embeddings (was: glyph-only pseudo-embedding)
+// ───────────────────────────────────────────────────────────────────────────
+describe('Content-aware embeddings', () => {
+  const provider = new DeterministicEmbeddingProvider();
+
+  it('serializes context stably regardless of key order', () => {
+    const a = serializeContext({ args: { b: 2, a: 1 } });
+    const b = serializeContext({ args: { a: 1, b: 2 } });
+    expect(a).toBe(b);
+    expect(a).not.toBe('');
+  });
+
+  it('returns frame-only embedding when no behavioral context (backward compatible)', () => {
+    const f = frame('⊕◊▶β');
+    const withoutContext = provider.embed({ frame: f });
+    const emptyContext = provider.embed({ frame: f, context: {} });
+    expect(withoutContext).toEqual(emptyContext);
+  });
+
+  it('produces different embeddings for same frame but different content', () => {
+    const f = frame('⊕◊▶β');
+    const e1 = provider.embed({ frame: f, context: { args: { amount: 100 } } });
+    const e2 = provider.embed({ frame: f, context: { args: { amount: 999999 } } });
+    expect(euclideanDistance(e1, e2)).toBeGreaterThan(0);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const f = frame('⊕◊▶β');
+    const e1 = provider.embed({ frame: f, context: { args: { amount: 100 } } });
+    const e2 = provider.embed({ frame: f, context: { args: { amount: 100 } } });
+    expect(e1).toEqual(e2);
+  });
+
+  it('content embedding is normalized and content-sensitive', () => {
+    const v = generateContentEmbedding('write_file:/etc/passwd');
+    const mag = Math.sqrt(v.reduce((s, x) => s + x * x, 0));
+    expect(mag).toBeCloseTo(1, 5);
+    expect(euclideanDistance(v, generateContentEmbedding('read_file:/tmp/ok'))).toBeGreaterThan(0);
+  });
+
+  it('blend respects weighting', () => {
+    const a = generateContentEmbedding('aaaa');
+    const b = generateContentEmbedding('bbbb');
+    expect(blendEmbeddings(a, b, 1)).toEqual(a);
+  });
+});
+
+describe('Drift reacts to behavioral content', () => {
+  beforeEach(() => driftEngine.reset());
+
+  it('accumulates non-zero drift when same frame is used with diverging content', () => {
+    const agent = 'drift-agent';
+    const f = '⊕◊▶β';
+    // Establish a stable pattern.
+    for (let i = 0; i < 6; i++) {
+      driftEngine.recordOperation(agent, f, 'pay', true, { args: { amount: 100 } });
+    }
+    // Then diverge sharply in content under the identical frame.
+    for (let i = 0; i < 6; i++) {
+      driftEngine.recordOperation(agent, f, 'pay', true, {
+        args: { amount: 10_000_000, dest: 'unknown' },
+      });
+    }
+    const status = driftEngine.getAgentStatus(agent);
+    expect(status.driftScore).toBeGreaterThan(0);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// GAP 4: Crypto-backed tripwire RNG (was: Math.random)
+// ───────────────────────────────────────────────────────────────────────────
+describe('Tripwire crypto RNG', () => {
+  it('honors injection rate bounds deterministically at extremes', () => {
+    const tw = new TripwireInjector();
+    tw.setInjectionRate(0);
+    expect(Array.from({ length: 50 }, () => tw.shouldInject()).some(Boolean)).toBe(false);
+    tw.setInjectionRate(1);
+    expect(Array.from({ length: 50 }, () => tw.shouldInject()).every(Boolean)).toBe(true);
+  });
+
+  it('returns well-formed tripwire cases', () => {
+    const tw = new TripwireInjector();
+    for (let i = 0; i < 20; i++) {
+      const t = tw.getRandomTripwire();
+      expect(['valid', 'invalid']).toContain(t.type);
+      expect(typeof t.frame).toBe('string');
+      expect(['accept', 'reject']).toContain(t.expectedOutcome);
+    }
+    expect(tw.getTripwire('valid').type).toBe('valid');
+    expect(tw.getTripwire('invalid').type).toBe('invalid');
+  });
+});

--- a/tests/unit/handshake/challenge.test.ts
+++ b/tests/unit/handshake/challenge.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { HandshakeProtocol, type HandshakeCapabilities } from '../../../src/handshake/protocol.js';
+
+const caps: HandshakeCapabilities = {
+  version: '0.2',
+  verbCount: 36,
+  status: 'active',
+  namespaces: ['ps:core'],
+};
+
+describe('Handshake HMAC challenge–response', () => {
+  it('verifies a correct proof for an issued challenge', () => {
+    const verifier = new HandshakeProtocol({ ...caps }, { secret: 'shared-secret' });
+    const prover = new HandshakeProtocol({ ...caps }, { secret: 'shared-secret' });
+
+    const challenge = verifier.issueChallenge();
+    expect(challenge.nonce).toMatch(/^[0-9a-f]{32}$/);
+
+    const mac = prover.proveChallenge(challenge.nonce);
+    expect(verifier.verifyChallenge(challenge.nonce, mac)).toEqual({ verified: true });
+  });
+
+  it('rejects a proof computed with the wrong secret', () => {
+    const verifier = new HandshakeProtocol({ ...caps }, { secret: 'right' });
+    const attacker = new HandshakeProtocol({ ...caps }, { secret: 'wrong' });
+
+    const { nonce } = verifier.issueChallenge();
+    const result = verifier.verifyChallenge(nonce, attacker.proveChallenge(nonce));
+    expect(result.verified).toBe(false);
+    expect(result.reason).toBe('MAC mismatch');
+  });
+
+  it('rejects unknown / replayed nonces (single-use)', () => {
+    const p = new HandshakeProtocol({ ...caps }, { secret: 's' });
+    const { nonce } = p.issueChallenge();
+    const mac = p.proveChallenge(nonce);
+
+    expect(p.verifyChallenge(nonce, mac).verified).toBe(true);
+    // Second attempt with same nonce must fail (consumed).
+    const replay = p.verifyChallenge(nonce, mac);
+    expect(replay.verified).toBe(false);
+    expect(replay.reason).toContain('Unknown');
+  });
+
+  it('rejects expired challenges', () => {
+    const p = new HandshakeProtocol({ ...caps }, { secret: 's', challengeTtlMs: -1 });
+    const { nonce } = p.issueChallenge();
+    const result = p.verifyChallenge(nonce, p.proveChallenge(nonce));
+    expect(result.verified).toBe(false);
+    expect(result.reason).toBe('Challenge expired');
+  });
+
+  it('rejects malformed MACs without throwing', () => {
+    const p = new HandshakeProtocol({ ...caps }, { secret: 's' });
+    const { nonce } = p.issueChallenge();
+    const result = p.verifyChallenge(nonce, 'not-hex-!!');
+    expect(result.verified).toBe(false);
+  });
+
+  it('reports ephemeral vs configured secret', () => {
+    expect(new HandshakeProtocol({ ...caps }).hasSharedSecret()).toBe(false);
+    expect(new HandshakeProtocol({ ...caps }, { secret: 'x' }).hasSharedSecret()).toBe(true);
+  });
+
+  it('preserves the existing version-check / echo behavior', () => {
+    const p = new HandshakeProtocol({ ...caps }, { secret: 's' });
+    expect(p.respond('::check{ps:version}').echo).toBe('ps:0.2 |verbs:36 |status:active');
+  });
+});


### PR DESCRIPTION
## Summary

A capability review found that several headline features were named but not actually implemented — the execution gate terminated in a simulator, drift "embeddings" carried no behavioral signal, and the "cryptographic" handshake was a string-equality check. This PR replaces those stubs with **real, working, test-covered implementations**, keeping safe defaults and full backward compatibility.

All four changes are conservative and reversible; the existing suite passes unchanged.

## What changed

### 1. Real execution seam (`src/gatekeeper/index.ts`)
- STEP 6 now runs a pluggable `ToolExecutor` when one is registered (`new Gatekeeper(eviction, { executor })` or `gatekeeper.setExecutor(...)`), otherwise it falls back to the built-in simulation — **simulation remains the default**, so behavior is unchanged unless an executor is wired in.
- Executor exceptions are recorded as **failed executions** (drift + audit) rather than crashing the pipeline.
- Synchronous by design to match the gatekeeper's sync `execute()` and the codebase's sync-I/O style (`better-sqlite3`).

### 2. Content-aware, pluggable drift embeddings (`src/utils/embedding-provider.ts`, `embeddings.ts`, `drift/*`)
- Previously the embedding was a function of the frame's symbol glyphs only — it contained **zero** information about what an agent actually did, so drift on an identical frame was always ~0.
- New `EmbeddingProvider` seam blends frame structure with **behavioral content** (tool args + results). Default provider is deterministic and local (no network/model dependency → latency preserved). Inject a real semantic model via `setEmbeddingProvider()`.
- Behavioral context is threaded through `DriftDetectionEngine.recordOperation` / `ContinuousMonitor.recordOperation` (new optional `OperationContext`), wired from `ps_execute` and the gatekeeper.
- **Backward compatible:** with no behavioral context, the provider returns exactly the old frame-only embedding.

### 3. Authenticated handshake (`src/handshake/protocol.ts`)
- Adds HMAC-SHA256 **challenge–response**: `issueChallenge()` / `proveChallenge()` / `verifyChallenge()` with single-use, expiring nonces and constant-time comparison.
- Secret from `PROMPTSPEAK_HANDSHAKE_SECRET`, falling back to an ephemeral per-process key.
- Existing version-check / parse-echo behavior is untouched.

### 4. Crypto-backed tripwire RNG (`src/drift/tripwire.ts`)
- `crypto.randomInt` replaces `Math.random` for injection decisions and case selection, removing predictability for an adversary who knows the injection rate.

## Testing
- Added `tests/unit/gap-fixes.test.ts` and `tests/unit/handshake/challenge.test.ts` (20 new tests) covering the executor seam (default/registered/throw/clear), content-sensitive & deterministic embeddings, drift reacting to behavioral content, crypto RNG bounds, and HMAC verify/reject/replay/expiry/malformed paths.
- **Full suite: 879 passing, 0 regressions.** `tsc` clean, production build clean.

## Notes / follow-ups
- The executor seam is synchronous. If async tool execution is needed, a dedicated async path would be a sensible follow-up (kept out of scope here to avoid a large blast radius on the sync `execute()` and its many callers/tests).
- Pipeline ordering and the immutable safety floor are unchanged, per the project's load-bearing-pipeline guidance.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012BGeXXkJEAKyfjnECNgazK)_